### PR TITLE
Fix the ImplementsModel decorator

### DIFF
--- a/BugTracker.App/Static/app/store/appStore.base.ts
+++ b/BugTracker.App/Static/app/store/appStore.base.ts
@@ -14,9 +14,9 @@ export class IReducerAppState {
 }
 
 export class AppState {
-    @ImplementsModel(CurrentUserState) public currentUser: CurrentUserState = new CurrentUserState();
-    @ImplementsModelList(UserModel) public users: List<UserModel> = List<UserModel>();
-    @ImplementsModelList(IssueModel) public issues: List<IssueModel> = List<IssueModel>();
+    @ImplementsModel(() => CurrentUserState) public currentUser: CurrentUserState = new CurrentUserState();
+    @ImplementsModelList(() => UserModel) public users: List<UserModel> = List<UserModel>();
+    @ImplementsModelList(() => IssueModel) public issues: List<IssueModel> = List<IssueModel>();
 
     constructor() { }
 }

--- a/BugTracker.App/Static/app/store/appStore.redux.ts
+++ b/BugTracker.App/Static/app/store/appStore.redux.ts
@@ -30,12 +30,12 @@ export function wrapMiddlewareWithRedux(...storeEnhancers: Function[]) {
 }
 
 function createModel(propName: string, propValue: any, propMeta: IMetaImplementsProperty) {
-    var propClass = <IMetaImplementsClassConstructor>propMeta.classConstructor;
+    var propClass = <IMetaImplementsClassConstructor>propMeta.getClassConstructor();
     var propClassProto = <IHasMetaImplements>propClass.prototype;
     var propRecord = <Record.Class>propClassProto.__metaImplements.classConstructor;
 
     // create for each property on the object a propper model if possible
-    manipulateModel(propValue, propMeta.classConstructor);
+    manipulateModel(propValue, propMeta.getClassConstructor());
 
     // create an instance of the target model
     var model = Object.create(propClassProto);

--- a/BugTracker.App/Static/app/store/storeModels.meta.tests.ts
+++ b/BugTracker.App/Static/app/store/storeModels.meta.tests.ts
@@ -160,8 +160,8 @@ const LevelOneModelRecord = Record(<ILevelOneModel>{
 @ImplementsClass(LevelOneModelRecord)
 class LevelOneModel extends LevelOneModelRecord implements ILevelOneModel {
     @ImplementsPoco() public name: string;
-    @ImplementsModel(LevelOneModel) public model: LevelOneModel;
-    @ImplementsModelList(LevelOneModel) public models: List<LevelOneModel>;
+    @ImplementsModel(() => LevelOneModel) public model: LevelOneModel;
+    @ImplementsModelList(() => LevelOneModel) public models: List<LevelOneModel>;
 
     public getName() {
         return this.name;
@@ -176,9 +176,6 @@ class LevelOneModel extends LevelOneModelRecord implements ILevelOneModel {
     }
 }
 
-// TODO: Attention!! The order of the classes are important 
-// because the <ModelType> in @ImplementsModel(<ModelType>) my be undefined if the class is not yet created!!
-
 interface IUserModel{
     name:string,
     pet:PetModel
@@ -190,7 +187,7 @@ const UserModelRecord = Record(<IUserModel>{
 @ImplementsClass(UserModelRecord)
 class UserModel extends UserModelRecord implements IUserModel{
     @ImplementsPoco() public name:string;
-    @ImplementsModel(PetModel) public pet:PetModel;
+    @ImplementsModel(() => PetModel) public pet:PetModel;
     public setName(name:string):UserModel{
         var newImmutable = <UserModel>this.withMutations(map => {
             map.set("name", name);
@@ -232,7 +229,7 @@ class PetModel extends PetModelRecord implements IPetModel{
 }
 
 class TestAppState {
-    @ImplementsModel(LevelOneModel) public model: LevelOneModel;
-    @ImplementsModelList(LevelOneModel) public models: List<LevelOneModel>;
-    @ImplementsModel(UserModel) public user: UserModel;
+    @ImplementsModel(() => LevelOneModel) public model: LevelOneModel;
+    @ImplementsModelList(() => LevelOneModel) public models: List<LevelOneModel>;
+    @ImplementsModel(() => UserModel) public user: UserModel;
 }

--- a/BugTracker.App/Static/app/store/storeModels.meta.tests.ts
+++ b/BugTracker.App/Static/app/store/storeModels.meta.tests.ts
@@ -179,32 +179,6 @@ class LevelOneModel extends LevelOneModelRecord implements ILevelOneModel {
 // TODO: Attention!! The order of the classes are important 
 // because the <ModelType> in @ImplementsModel(<ModelType>) my be undefined if the class is not yet created!!
 
-interface IPetModel{
-    name:string,
-    transform(name:string):PetModel,
-    bark():string
-}
-const PetModelRecord = Record(<IPetModel>{
-    name:<string>null
-})
-@ImplementsClass(PetModelRecord)
-class PetModel extends PetModelRecord implements IPetModel{
-    @ImplementsPoco() public name:string;
-    public bark(){
-        return this.name;
-    }
-    public transform(name:string){
-        return <PetModel>this.withMutations(map => {
-            map.set("name", name);
-        });
-    }
-    constructor(name:string=null){
-        super({
-            name
-        })
-    }
-}
-
 interface IUserModel{
     name:string,
     pet:PetModel
@@ -227,6 +201,32 @@ class UserModel extends UserModelRecord implements IUserModel{
         super({
             name,
             pet
+        })
+    }
+}
+
+interface IPetModel{
+    name:string,
+    transform(name:string):PetModel,
+    bark():string
+}
+const PetModelRecord = Record(<IPetModel>{
+    name:<string>null
+})
+@ImplementsClass(PetModelRecord)
+class PetModel extends PetModelRecord implements IPetModel{
+    @ImplementsPoco() public name:string;
+    public bark(){
+        return this.name;
+    }
+    public transform(name:string){
+        return <PetModel>this.withMutations(map => {
+            map.set("name", name);
+        });
+    }
+    constructor(name:string=null){
+        super({
+            name
         })
     }
 }

--- a/BugTracker.App/Static/app/store/storeModels.meta.ts
+++ b/BugTracker.App/Static/app/store/storeModels.meta.ts
@@ -15,7 +15,7 @@ export interface IMetaImplementsClassConstructor extends Function, IHasMetaImple
 
 export interface IMetaImplementsProperty {
     name: string,
-    classConstructor: IMetaImplementsClassConstructor,
+    getClassConstructor: () => IMetaImplementsClassConstructor,
     isList: boolean,
     isPoco: boolean
 }
@@ -51,7 +51,7 @@ export function ImplementsPoco() {
             setMetaDataIfMissing(hasMetaImplements);
             hasMetaImplements.__metaImplements.properties[propertyKey] = {
                 name: propertyKey,
-                classConstructor: null,
+                getClassConstructor: null,
                 isList: false,
                 isPoco: true
             };
@@ -90,7 +90,7 @@ function InternalImplementsModel(Class: Function, isList: boolean) {
             setMetaDataIfMissing(hasMetaImplements);
             hasMetaImplements.__metaImplements.properties[propertyKey] = {
                 name: propertyKey,
-                classConstructor: Class,
+                getClassConstructor: () => Class,
                 isList: isList,
                 isPoco: false
             };

--- a/BugTracker.App/Static/app/store/storeModels.meta.ts
+++ b/BugTracker.App/Static/app/store/storeModels.meta.ts
@@ -46,12 +46,12 @@ export function ImplementsClass(Class: Function) {
         args);
 }
 
-export function ImplementsModelList(Class: Function) {
-    return InternalImplementsModel(Class, true);
+export function ImplementsModelList(getClass: () => Function) {
+    return InternalImplementsModel(getClass, true);
 }
 
-export function ImplementsModel(Class: Function) {
-    return InternalImplementsModel(Class, false);
+export function ImplementsModel(getClass: () => Function) {
+    return InternalImplementsModel(getClass, false);
 }
 
 export function ImplementsPoco() {
@@ -76,7 +76,7 @@ export function ImplementsPoco() {
         args);
 }
 
-function InternalImplementsModel(Class: Function, isList: boolean) {
+function InternalImplementsModel(getClass: () => Function, isList: boolean) {
     return (...args: any[]) => getDecorator(
         null, 
         (prototype: Function, propertyKey: string, descriptor?: TypedPropertyDescriptor<any>): void => {
@@ -86,7 +86,7 @@ function InternalImplementsModel(Class: Function, isList: boolean) {
             setMetaDataIfMissing(hasMetaImplements);
             hasMetaImplements.__metaImplements.properties[propertyKey] = {
                 name: propertyKey,
-                getClassConstructor: () => Class,
+                getClassConstructor: getClass,
                 isList: isList,
                 isPoco: false
             };

--- a/BugTracker.App/Static/app/store/storeModels.ts
+++ b/BugTracker.App/Static/app/store/storeModels.ts
@@ -65,7 +65,7 @@ const CurrentUserStateRecord = Record(<ICurrentUserState>{
 @ImplementsClass(CurrentUserStateRecord)
 export class CurrentUserState extends CurrentUserStateRecord implements ICurrentUserState {
     @ImplementsPoco() public isSet: boolean;
-    @ImplementsModel(UserModel) public user: UserModel;
+    @ImplementsModel(() => UserModel) public user: UserModel;
 
     public setUser(value?: UserModel): CurrentUserState {
         return <CurrentUserState>this.withMutations(map => {


### PR DESCRIPTION
The order of the models now not important anymore because we now pass a
function with access to the local scope to the decorator which is now
able to resolve the type on request.