### PR TITLE
WebApi connect, form validation, routing

### DIFF
--- a/BugTracker.App/BugTracker.App.csproj
+++ b/BugTracker.App/BugTracker.App.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Attributes\ReturnsVoidAttribute.cs" />
     <Compile Include="Attributes\TypescriptIterable.cs" />
     <Compile Include="Attributes\TypescriptIterableTypeAttribute.cs" />
+    <Compile Include="Commands\UpdateIssueCommand.cs" />
     <Compile Include="Commands\CreateNewIssueCommand.cs" />
     <Compile Include="Commands\RegisterNewUserCommand.cs" />
     <Compile Include="Commands\RegisterNewUserIfUnknownCommand.cs" />

--- a/BugTracker.App/Commands/Repository/Abstract/ICommandRepository.cs
+++ b/BugTracker.App/Commands/Repository/Abstract/ICommandRepository.cs
@@ -8,5 +8,6 @@ namespace BugTracker.App.Commands.Repository.Abstract
         CommandBase<UserModel> RegisterNewUser(RegisterUserModel registrationModel);
         CommandBase<UserModel> RegisterNewUserIfUnknown(RegisterUserModel registrationModel);
         CommandBase<IssueModel> CreateNewIssue(IssueModel issueModel);
+        CommandBase UpdateIssue(IssueModel issueModel);
     }
 }

--- a/BugTracker.App/Commands/Repository/CommandRepository.cs
+++ b/BugTracker.App/Commands/Repository/CommandRepository.cs
@@ -34,5 +34,12 @@ namespace BugTracker.App.Commands.Repository
             command.Initialize(issueModel);
             return command;
         }
+
+        public CommandBase UpdateIssue(IssueModel issueModel)
+        {
+            var command = this.commandFactory.CreateCommand<UpdateIssueCommand>();
+            command.Initialize(issueModel);
+            return command;
+        }
     }
 }

--- a/BugTracker.App/Commands/UpdateIssueCommand.cs
+++ b/BugTracker.App/Commands/UpdateIssueCommand.cs
@@ -1,0 +1,60 @@
+﻿using System.Threading.Tasks;
+using AutoMapper;
+using BugTracker.App.Models;
+using BugTracker.Data.Repositories.Abstract;
+using BugTracker.Shared.Command.Abstract;
+using BugTracker.Shared.Command.Entities;
+using BugTracker.Shared.Extensions;
+
+namespace BugTracker.App.Commands
+{
+    internal class UpdateIssueCommand : CommandBase
+    {
+        private readonly IIssueAccess issueAccess;
+        private readonly IUserAccess userAccess;
+        private IssueModel issueModel;
+
+        public UpdateIssueCommand (IIssueAccess issueAccess, IUserAccess userAccess)
+        {
+            this.issueAccess = issueAccess;
+            this.userAccess = userAccess;
+        }
+
+        public void Initialize(IssueModel issueModel)
+        {
+            this.issueModel = issueModel;
+        }
+
+        protected override Task<CanExecuteCommandResult> CanExecuteAsync()
+        {
+            if (this.issueModel == null)
+            {
+                return this.CannotExecute("The issue model is null.").ToTaskResult();
+            }
+            if (string.IsNullOrWhiteSpace(this.issueModel.Title))
+            {
+                return this.CannotExecute("The title is null or empty.").ToTaskResult();
+            }
+            if (string.IsNullOrWhiteSpace(this.issueModel.Content))
+            {
+                return this.CannotExecute("The content is null or empty.").ToTaskResult();
+            }
+            this.issueModel.Title = this.issueModel.Title.Trim();
+            this.issueModel.Content = this.issueModel.Content.Trim();
+
+            var maybeUser = this.userAccess.TryGetById(this.issueModel.UserId);
+            if (maybeUser.HasNoValue)
+            {
+                return this.CannotExecute($"The user with id {this.issueModel.UserId} does not exist.").ToTaskResult();
+            }
+
+            return base.CanExecuteAsync();
+        }
+
+        protected override Task<CommandResult> ExecuteAsync()
+        {
+            this.issueAccess.Update(this.issueModel.Id, this.issueModel.Title, this.issueModel.Content, this.issueModel.IsClosed);
+            return this.SuccessExecution().ToTaskResult();
+        }
+    }
+}

--- a/BugTracker.App/Controllers/IssueController.cs
+++ b/BugTracker.App/Controllers/IssueController.cs
@@ -52,6 +52,25 @@ namespace BugTracker.App.Controllers
             return response;
         }
 
+        [ReturnsVoid]
+        [HttpPut, Route("Update")]
+        public async Task<HttpResponseMessage> Update(IssueModel issueModel)
+        {
+            HttpResponseMessage response;
+            if (issueModel == null)
+            {
+                response = this.CreateErrorResponse("The issueModel is not set.", HttpStatusCode.BadRequest);
+                return response;
+            }
+
+            var updateIssueCommand = this.commandRepository.UpdateIssue(issueModel);
+            var commandResult = await this.commandExecutor.ExecuteAsync(updateIssueCommand);
+
+            response = this.CreateResponseFromCommandResult(commandResult);
+            return response;
+        }
+
+
         [ReturnsModels(TypescriptIterable.List, nameof(IssueModel))]
         [HttpGet, Route("GetAllByUser")]
         public HttpResponseMessage GetAllByUser(Guid userId)

--- a/BugTracker.App/Static/app/app.ts
+++ b/BugTracker.App/Static/app/app.ts
@@ -1,19 +1,20 @@
 ﻿import { Component, provide } from "angular2/core";
 import { HTTP_PROVIDERS, RequestOptions  } from 'angular2/http';
-import { Router, RouteConfig, ROUTER_DIRECTIVES, ROUTER_PROVIDERS,  APP_BASE_HREF } from "angular2/router";
+import { Router, RouteConfig, ROUTER_DIRECTIVES, ROUTER_PROVIDERS, APP_BASE_HREF } from "angular2/router";
 
 import { bootstrap } from "angular2/platform/browser";
-import { DefaultRequestOptions } from "./services/service.base";
+import { DefaultRequestOptions } from "./utils/defaultRequestOptions";
 import { AppStore, appStoreFactory } from "./store/appStore";
 import { AppConfiguration } from './config/config.base';
 
-import { CurrentUserState } from "./models/models";
-import { APP_WEBSERVICES } from "./services/services"
+import { APP_WEBSERVICES, AUTH_SERVICES } from "./services/services"
+import { AuthService } from "./services/authService"
 
 import { AppHeaderComponent } from "./features/common/view/appHeaderComponent";
 import { UserLogin } from "./features/currentUser/view/userLoginComponent";
 import { IssuesContainer } from "./features/issues/view/issuesContainerComponent";
 import { EditIussue } from "./features/issues/view/editIssueCompontent";
+import { CurrentUserStoreActions } from "./features/currentUser/store/currentUserStoreActions";
 
 @RouteConfig([
     { path: '/login', name: 'Login', component: UserLogin, useAsDefault: true },
@@ -36,22 +37,22 @@ import { EditIussue } from "./features/issues/view/editIssueCompontent";
 })
 
 export class App {
-    public currentUser: CurrentUserState;
-    constructor(private appStore: AppStore) {
-        appStore.subscribe(this.appStoreUpdate.bind(this));
-        this.appStoreUpdate();
-    }
-    private appStoreUpdate() {
-        this.currentUser = this.appStore.getState().currentUser;
+
+    constructor(private appStore: AppStore, private authService: AuthService, private router : Router) {
+        var currentUser = this.authService.getUserFromLocalStorage();
+        if (currentUser != null) {
+            this.appStore.dispatch(CurrentUserStoreActions.SetCurrentUser(currentUser));
+        }
     }
 }
 
 var appConfiguration = new AppConfiguration((<any>window).appConfiguration);
 
 bootstrap(App, [
-    HTTP_PROVIDERS,    
+    HTTP_PROVIDERS,
     APP_WEBSERVICES,
     ROUTER_PROVIDERS,
+    AUTH_SERVICES,
     provide(APP_BASE_HREF, { useValue: '/static' }),
     provide(AppConfiguration, { useValue: appConfiguration }),
     provide(RequestOptions, { useClass: DefaultRequestOptions }),

--- a/BugTracker.App/Static/app/app.ts
+++ b/BugTracker.App/Static/app/app.ts
@@ -1,5 +1,6 @@
 ﻿import { Component, provide } from "angular2/core";
 import { HTTP_PROVIDERS, RequestOptions  } from 'angular2/http';
+import { ROUTER_PROVIDERS } from 'angular2/router';
 import { bootstrap } from "angular2/platform/browser";
 import { DefaultRequestOptions } from "./services/service.base";
 import { AppStore, appStoreFactory } from "./store/appStore";
@@ -11,15 +12,19 @@ import { APP_WEBSERVICES } from "./services/services"
 import { UserLogin } from "./features/currentUser/view/userLoginComponent";
 import { UserAvatar } from "./features/currentUser/view/userAvatarComponent";
 import { IssuesContainer } from "./features/issues/view/issuesContainerComponent";
+import { EditIussue } from "./features/issues/view/editIssueCompontent";
 
 @Component({
     selector: "bug-tracker",
-    directives: [UserLogin, UserAvatar, IssuesContainer],
+    directives: [UserLogin, UserAvatar, IssuesContainer, EditIussue],
     template: `
         <div>
             <user-login *ngIf="currentUser.user == null"></user-login>
             <user-avatar *ngIf="currentUser.user != null"></user-avatar>
             <issues-container *ngIf="currentUser.user != null"></issues-container>
+        </div>
+        <div>
+            <edit-issue *ngIf="currentUser.user != null"></edit-issue>
         </div>
     `
 })
@@ -39,6 +44,7 @@ var appConfiguration = new AppConfiguration((<any>window).appConfiguration);
 
 bootstrap(App, [
     HTTP_PROVIDERS,
+    ROUTER_PROVIDERS,
     APP_WEBSERVICES,
     provide(AppConfiguration, { useValue: appConfiguration }),
     provide(RequestOptions, { useClass: DefaultRequestOptions }),

--- a/BugTracker.App/Static/app/app.ts
+++ b/BugTracker.App/Static/app/app.ts
@@ -1,6 +1,7 @@
 ﻿import { Component, provide } from "angular2/core";
 import { HTTP_PROVIDERS, RequestOptions  } from 'angular2/http';
-import { ROUTER_PROVIDERS } from 'angular2/router';
+import { Router, RouteConfig, ROUTER_DIRECTIVES, ROUTER_PROVIDERS,  APP_BASE_HREF } from "angular2/router";
+
 import { bootstrap } from "angular2/platform/browser";
 import { DefaultRequestOptions } from "./services/service.base";
 import { AppStore, appStoreFactory } from "./store/appStore";
@@ -9,22 +10,27 @@ import { AppConfiguration } from './config/config.base';
 import { CurrentUserState } from "./models/models";
 import { APP_WEBSERVICES } from "./services/services"
 
+import { AppHeaderComponent } from "./features/common/view/appHeaderComponent";
 import { UserLogin } from "./features/currentUser/view/userLoginComponent";
-import { UserAvatar } from "./features/currentUser/view/userAvatarComponent";
 import { IssuesContainer } from "./features/issues/view/issuesContainerComponent";
 import { EditIussue } from "./features/issues/view/editIssueCompontent";
 
+@RouteConfig([
+    { path: '/login', name: 'Login', component: UserLogin, useAsDefault: true },
+    { path: '/issues', name: 'Issues', component: IssuesContainer },
+    { path: '/editIssue', name: 'NewIssues', component: EditIussue },
+    { path: '/editIssue/:id', name: 'EditIssues', component: EditIussue }
+])
+
 @Component({
     selector: "bug-tracker",
-    directives: [UserLogin, UserAvatar, IssuesContainer, EditIussue],
+    directives: [AppHeaderComponent, ROUTER_DIRECTIVES],
     template: `
         <div>
-            <user-login *ngIf="currentUser.user == null"></user-login>
-            <user-avatar *ngIf="currentUser.user != null"></user-avatar>
-            <issues-container *ngIf="currentUser.user != null"></issues-container>
-        </div>
-        <div>
-            <edit-issue *ngIf="currentUser.user != null"></edit-issue>
+            <app-header></app-header>
+            
+            <!-- Routed views go here -->
+            <router-outlet></router-outlet>
         </div>
     `
 })
@@ -43,9 +49,10 @@ export class App {
 var appConfiguration = new AppConfiguration((<any>window).appConfiguration);
 
 bootstrap(App, [
-    HTTP_PROVIDERS,
-    ROUTER_PROVIDERS,
+    HTTP_PROVIDERS,    
     APP_WEBSERVICES,
+    ROUTER_PROVIDERS,
+    provide(APP_BASE_HREF, { useValue: '/static' }),
     provide(AppConfiguration, { useValue: appConfiguration }),
     provide(RequestOptions, { useClass: DefaultRequestOptions }),
     provide(AppStore, { useFactory: appStoreFactory })

--- a/BugTracker.App/Static/app/features/common/view/appHeaderComponent.ts
+++ b/BugTracker.App/Static/app/features/common/view/appHeaderComponent.ts
@@ -1,0 +1,43 @@
+import { Component, OnInit, OnDestroy, ChangeDetectionStrategy, ChangeDetectorRef } from "angular2/core";
+import { ROUTER_DIRECTIVES } from "angular2/router";
+import { AppStore } from "../../../store/appStore";
+import { CurrentUserState } from "../../../models/models";
+import { UserAvatar } from "../../currentUser/view/userAvatarComponent";
+
+@Component({
+    selector: "app-header",
+    changeDetection: ChangeDetectionStrategy.Detached,
+    directives: [UserAvatar, ROUTER_DIRECTIVES],
+    template: `
+        <div>
+            <user-avatar *ngIf="currentUser.user != null"></user-avatar>
+            <hr>
+            <nav>
+                <a [routerLink]="['Login']" *ngIf="currentUser.user == null">Login</a>
+                <a [routerLink]="['Issues']" *ngIf="currentUser.user != null">Issues</a>
+            </nav>
+            <hr>
+        </div>
+    `
+})
+
+export class AppHeaderComponent implements OnInit, OnDestroy {
+    private appStoreUnsubscribe: Function;
+    public currentUser: CurrentUserState;
+    constructor(private appStore: AppStore, private changeDetectorRef: ChangeDetectorRef) {
+    }
+    onAppStoreUpdate() {
+        this.appStoreUpdate();
+        this.changeDetectorRef.markForCheck();
+    }
+    ngOnInit() {
+        this.appStoreUnsubscribe = this.appStore.subscribe(this.onAppStoreUpdate.bind(this));
+        this.onAppStoreUpdate();
+    }
+    ngOnDestroy() {
+        this.appStoreUnsubscribe();
+    }
+    private appStoreUpdate() {
+        this.currentUser = this.appStore.getState().currentUser;
+    }
+}

--- a/BugTracker.App/Static/app/features/currentUser/view/userAvatarComponent.ts
+++ b/BugTracker.App/Static/app/features/currentUser/view/userAvatarComponent.ts
@@ -3,6 +3,7 @@ import { Router } from "angular2/router";
 import { AppStore } from "../../../store/appStore";
 
 import { CurrentUserStoreActions } from "../../currentUser/store/currentUserStoreActions";
+import { AuthService } from "../../../services/authService"
 
 @Component({
     selector: "user-avatar",
@@ -16,7 +17,7 @@ import { CurrentUserStoreActions } from "../../currentUser/store/currentUserStor
 
 export class UserAvatar implements OnInit, OnDestroy {
     private appStoreUnsubscribe: Function;
-    constructor(private appStore: AppStore, private changeDetectorRef: ChangeDetectorRef, private router : Router) {
+    constructor(private appStore: AppStore, private changeDetectorRef: ChangeDetectorRef, private router : Router, private authService : AuthService) {
     }
     onAppStoreUpdate() {
         this.changeDetectorRef.markForCheck();
@@ -29,6 +30,7 @@ export class UserAvatar implements OnInit, OnDestroy {
         this.appStoreUnsubscribe();
     }
     logout() {
+        this.authService.removeUserFromLocalStorage();
         this.appStore.dispatch(CurrentUserStoreActions.RemoveCurrentUser());
         this.router.navigate(['Login']);
     }

--- a/BugTracker.App/Static/app/features/currentUser/view/userAvatarComponent.ts
+++ b/BugTracker.App/Static/app/features/currentUser/view/userAvatarComponent.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, OnInit, ChangeDetectionStrategy, ChangeDetectorRef } from "angular2/core";
+import { Router } from "angular2/router";
 import { AppStore } from "../../../store/appStore";
 
 import { CurrentUserStoreActions } from "../../currentUser/store/currentUserStoreActions";
@@ -15,7 +16,7 @@ import { CurrentUserStoreActions } from "../../currentUser/store/currentUserStor
 
 export class UserAvatar implements OnInit, OnDestroy {
     private appStoreUnsubscribe: Function;
-    constructor(private appStore: AppStore, private changeDetectorRef: ChangeDetectorRef) {
+    constructor(private appStore: AppStore, private changeDetectorRef: ChangeDetectorRef, private router : Router) {
     }
     onAppStoreUpdate() {
         this.changeDetectorRef.markForCheck();
@@ -29,5 +30,6 @@ export class UserAvatar implements OnInit, OnDestroy {
     }
     logout() {
         this.appStore.dispatch(CurrentUserStoreActions.RemoveCurrentUser());
+        this.router.navigate(['Login']);
     }
 }

--- a/BugTracker.App/Static/app/features/currentUser/view/userLoginComponent.ts
+++ b/BugTracker.App/Static/app/features/currentUser/view/userLoginComponent.ts
@@ -1,6 +1,7 @@
 import { Component, Inject } from "angular2/core";
-import { AppStore } from "../../../store/appStore";
+import { Router } from "angular2/router";
 
+import { AppStore } from "../../../store/appStore";
 import { CurrentUserStoreActions } from "../../currentUser/store/currentUserStoreActions";
 import { UserModel, RegisterUserModel } from '../../../models/models';
 import { UserService } from '../../../services/services';
@@ -17,7 +18,7 @@ import { UserService } from '../../../services/services';
 })
 
 export class UserLogin {
-    constructor(private appStore: AppStore, private userService : UserService) {
+    constructor(private appStore: AppStore, private userService : UserService, private router : Router) {
     }
     
     login(input: HTMLInputElement) {
@@ -28,12 +29,11 @@ export class UserLogin {
         }
         
         var model = new RegisterUserModel().setUsername(username);
-        
-        
+               
         this.userService.registerIfUnknown(model).then(
             model => {
                 this.appStore.dispatch(CurrentUserStoreActions.SetCurrentUser(model));
-                input.value = '';
+                this.router.navigate(['Issues']);
             },
             error => console.error("error", error));
     }

--- a/BugTracker.App/Static/app/features/currentUser/view/userLoginComponent.ts
+++ b/BugTracker.App/Static/app/features/currentUser/view/userLoginComponent.ts
@@ -3,8 +3,9 @@ import { Router } from "angular2/router";
 
 import { AppStore } from "../../../store/appStore";
 import { CurrentUserStoreActions } from "../../currentUser/store/currentUserStoreActions";
-import { UserModel, RegisterUserModel } from '../../../models/models';
+import { UserModel, IUserModelUpdate, RegisterUserModel } from '../../../models/models';
 import { UserService } from '../../../services/services';
+import { AuthService } from '../../../services/authService';
 
 @Component({
     selector: "user-login",
@@ -18,7 +19,13 @@ import { UserService } from '../../../services/services';
 })
 
 export class UserLogin {
-    constructor(private appStore: AppStore, private userService : UserService, private router : Router) {
+    
+    constructor(private appStore: AppStore, private userService : UserService, private router : Router, private authService : AuthService) {
+        var currentUser = this.authService.getUserFromLocalStorage();
+        if (currentUser != null) {
+            this.appStore.dispatch(CurrentUserStoreActions.SetCurrentUser(currentUser));
+            this.router.navigate(['Issues']);
+        }
     }
     
     login(input: HTMLInputElement) {
@@ -32,6 +39,7 @@ export class UserLogin {
                
         this.userService.registerIfUnknown(model).then(
             model => {
+                this.authService.setUserToLocalStorage(model);
                 this.appStore.dispatch(CurrentUserStoreActions.SetCurrentUser(model));
                 this.router.navigate(['Issues']);
             },

--- a/BugTracker.App/Static/app/features/issues/store/issueStoreActions.ts
+++ b/BugTracker.App/Static/app/features/issues/store/issueStoreActions.ts
@@ -4,17 +4,24 @@ import { IssueModel } from "../../../models/models";
 const actionPrefix = "ISSUES.";
 export class IssueStoreActionTypes {
     public static ADD_ISSUE = actionPrefix + "ADD_ISSUE";
+    public static UPDATE_ISSUE = actionPrefix + "UPDATE_ISSUE";
     public static CHANGE_TITLE = actionPrefix + "CHANGE_TITLE";
 }
 export class IssueStoreActions {
     public static AddIssue = (issueModel: IssueModel): IAddIssueAction => {
         return createAction<IAddIssueAction>(IssueStoreActionTypes.ADD_ISSUE, { issue: issueModel });
     }
+    public static UpdateIssue = (issueModel: IssueModel): IUpdateIssueAction => {
+        return createAction<IUpdateIssueAction>(IssueStoreActionTypes.UPDATE_ISSUE, { issue: issueModel });
+    }
     public static ChangeTitle = (title: string): IChangeTitleAction => {
         return createAction<IChangeTitleAction>(IssueStoreActionTypes.CHANGE_TITLE, { title: title });
     }
 }
 export interface IAddIssueAction extends IAction {
+    payload: { issue: IssueModel };
+}
+export interface IUpdateIssueAction extends IAction {
     payload: { issue: IssueModel };
 }
 export interface IChangeTitleAction extends IAction {

--- a/BugTracker.App/Static/app/features/issues/store/issueStoreReducers.ts
+++ b/BugTracker.App/Static/app/features/issues/store/issueStoreReducers.ts
@@ -2,8 +2,17 @@ import { List } from 'immutable';
 
 import { IAction } from "../../../store/appStore.base";
 import { AppState, IssueModel } from "../../../models/models";
-import { IssueStoreActionTypes, IAddIssueAction, IChangeTitleAction } from "./issueStoreActions";
+import { IssueStoreActionTypes, IAddIssueAction, IUpdateIssueAction, IChangeTitleAction } from "./issueStoreActions";
 
+function updateIssue(state: List<IssueModel>, action: IUpdateIssueAction): List<IssueModel> {
+    var itemIndex = state.findIndex(x => x.id == action.payload.issue.id);
+    if (itemIndex < 0)
+    {
+        return state;    
+    }    
+    var newState = state.set(itemIndex ,action.payload.issue);
+    return newState;
+}
 function addIssue(state: List<IssueModel>, action: IAddIssueAction): List<IssueModel> {
     var newState = state.push(action.payload.issue);
     return newState;
@@ -17,6 +26,8 @@ export function issueStoreReducer(state: List<IssueModel> = List<IssueModel>(), 
     switch (action.type) {
         case IssueStoreActionTypes.ADD_ISSUE:
             return addIssue(state, <IAddIssueAction>action);
+        case IssueStoreActionTypes.UPDATE_ISSUE:
+            return updateIssue(state, <IUpdateIssueAction>action);
         case IssueStoreActionTypes.CHANGE_TITLE:
             return changeTitle(state, <IChangeTitleAction>action);
         default:

--- a/BugTracker.App/Static/app/features/issues/view/editIssueCompontent.ts
+++ b/BugTracker.App/Static/app/features/issues/view/editIssueCompontent.ts
@@ -1,0 +1,114 @@
+import { Component, Input, OnDestroy, OnInit, ChangeDetectionStrategy, ChangeDetectorRef } from "angular2/core";
+import {RouteParams} from 'angular2/router';
+import {NgForm, Control, ControlGroup, FormBuilder, Validators } from 'angular2/common';
+
+import { AppStore } from "../../../store/appStore";
+import { IssueModel } from "../../../models/models";
+
+@Component(
+    {
+        selector: "edit-issue",
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        template: `
+            <form (ngSubmit)="onSubmit()" [ngFormModel]="issueForm">
+                <div class="form-group">
+                    <label for="title">Title</label>
+                    <input required type="title" class="form-control" id="title" [ngModel]="issue.title" ngControl="title"  #title="ngForm">
+                </div>
+                
+                <div [hidden]="title.control.valid" class="alert alert-danger">
+                    Title is required
+                </div> 
+                
+                <div class="form-group">
+                    <label for="content">Content</label>
+                    <textarea class="form-control" rows="5" id="content" [ngModel]="issue.content" ngControl="content" #content="ngForm"></textarea>
+                </div>
+                <div [hidden]="!content.control.hasError('startWithPlatos')" class="alert alert-danger">
+                    Content must start with 'Platos'
+                </div> 
+                
+                <div class="form-group">
+                    <label for="reportedDate">Closed</label>
+                    <input type="checkbox" value="">
+                </div>
+                <button type="submit" class="btn btn-default">Save</button>
+            </form>
+        `
+    })
+
+
+export class EditIussue implements OnInit, OnDestroy {
+    private appStoreUnsubscribe: Function;
+    @Input() issue = new IssueModel({ title: "Test1", content: "Testcontent 1" });
+    @Input() simpleModel = new SimpleModel("Test1", "Test Content 1");
+    issueForm: ControlGroup;
+    
+    constructor(private appStore: AppStore, private fb: FormBuilder, private changeDetectorRef: ChangeDetectorRef /*, private routeParams: RouteParams*/) {
+        
+         this.issueForm = fb.group({
+             'title': ['', Validators.required],
+             'content':  ['', CustomValidators.startWithPlatos]  
+         }); 
+    
+        /*this.issue.
+        this.issue.setTitle("");
+        this.issue.setContent("");*/
+        
+        //this.issue.setTitle("test");
+        //console.log("tet");
+        // TODO: find issues based the id in the route parameter
+        //var issueId = routeParams.get('id'); 
+        
+        //this.issue = appStore.getState().issues.first();
+    }
+
+    onAppStoreUpdate() {
+        /*this.issue = this.appStore.getState().issues.first();
+        if (this.issue != null) {
+            console.log("TITEL: " + this.issue.title);
+            this.changeDetectorRef.markForCheck();
+        }*/
+    }
+    ngOnInit() {
+        // this.appStoreUnsubscribe = this.appStore.subscribe(this.onAppStoreUpdate.bind(this));
+        // this.onAppStoreUpdate();
+    }
+
+    ngOnDestroy() {
+        // this.appStoreUnsubscribe();
+    }
+
+    public onSubmit() {
+        // call webApi
+        
+        // store dispatch
+        
+        // change route to issues list
+        
+        console.log("Changed object: " + this.issue);
+    }
+}
+
+export class SimpleModel {
+    title: string;
+    content: string;
+    
+    constructor (title: string, content: string)
+    {
+        this.title = title;
+        this.content = content;
+    }
+}
+
+
+
+export class CustomValidators {  
+  static startWithPlatos(c: Control): ValidationResult  {  
+    return !c.value.match(/^Platos/) ? {"startWithPlatos": true} : null;  
+  }
+}
+
+interface ValidationResult {
+ [key:string]:boolean;
+}

--- a/BugTracker.App/Static/app/features/issues/view/editIssueCompontent.ts
+++ b/BugTracker.App/Static/app/features/issues/view/editIssueCompontent.ts
@@ -3,7 +3,7 @@ import {RouteParams} from 'angular2/router';
 import {NgForm, Control, ControlGroup, FormBuilder, Validators } from 'angular2/common';
 
 import { AppStore } from "../../../store/appStore";
-import { IssueModel } from "../../../models/models";
+import { IssueModel, IIssueModelUpdate } from "../../../models/models";
 
 @Component(
     {
@@ -13,7 +13,7 @@ import { IssueModel } from "../../../models/models";
             <form (ngSubmit)="onSubmit()" [ngFormModel]="issueForm">
                 <div class="form-group">
                     <label for="title">Title</label>
-                    <input required type="title" class="form-control" id="title" [ngModel]="issue.title" ngControl="title"  #title="ngForm">
+                    <input required type="title" class="form-control" id="title" [(ngModel)]="editModel.title" ngControl="title"  #title="ngForm">
                 </div>
                 
                 <div [hidden]="title.control.valid" class="alert alert-danger">
@@ -22,7 +22,7 @@ import { IssueModel } from "../../../models/models";
                 
                 <div class="form-group">
                     <label for="content">Content</label>
-                    <textarea class="form-control" rows="5" id="content" [ngModel]="issue.content" ngControl="content" #content="ngForm"></textarea>
+                    <textarea class="form-control" rows="5" id="content" [(ngModel)]="editModel.content" ngControl="content" #content="ngForm"></textarea>
                 </div>
                 <div [hidden]="!content.control.hasError('startWithPlatos')" class="alert alert-danger">
                     Content must start with 'Platos'
@@ -40,16 +40,17 @@ import { IssueModel } from "../../../models/models";
 
 export class EditIussue implements OnInit, OnDestroy {
     private appStoreUnsubscribe: Function;
+    private editModel: IIssueModelUpdate;
     @Input() issue = new IssueModel({ title: "Test1", content: "Testcontent 1" });
     @Input() simpleModel = new SimpleModel("Test1", "Test Content 1");
     issueForm: ControlGroup;
-    
+
     constructor(private appStore: AppStore, private fb: FormBuilder, private changeDetectorRef: ChangeDetectorRef /*, private routeParams: RouteParams*/) {
-        
-         this.issueForm = fb.group({
-             'title': ['', Validators.required],
-             'content':  ['', CustomValidators.startWithPlatos]  
-         }); 
+
+        this.issueForm = fb.group({
+            'title': ['', Validators.required],
+            'content': ['', CustomValidators.startWithPlatos]
+        }); 
     
         /*this.issue.
         this.issue.setTitle("");
@@ -71,6 +72,7 @@ export class EditIussue implements OnInit, OnDestroy {
         }*/
     }
     ngOnInit() {
+        this.editModel = <IIssueModelUpdate> this.issue.toJS();
         // this.appStoreUnsubscribe = this.appStore.subscribe(this.onAppStoreUpdate.bind(this));
         // this.onAppStoreUpdate();
     }
@@ -86,16 +88,15 @@ export class EditIussue implements OnInit, OnDestroy {
         
         // change route to issues list
         
-        console.log("Changed object: " + this.issue);
+        console.log("Changed object: ", new IssueModel(this.editModel));
     }
 }
 
 export class SimpleModel {
     title: string;
     content: string;
-    
-    constructor (title: string, content: string)
-    {
+
+    constructor(title: string, content: string) {
         this.title = title;
         this.content = content;
     }
@@ -103,12 +104,12 @@ export class SimpleModel {
 
 
 
-export class CustomValidators {  
-  static startWithPlatos(c: Control): ValidationResult  {  
-    return !c.value.match(/^Platos/) ? {"startWithPlatos": true} : null;  
-  }
+export class CustomValidators {
+    static startWithPlatos(c: Control): ValidationResult {
+        return !c.value.match(/^Platos/) ? { "startWithPlatos": true } : null;
+    }
 }
 
 interface ValidationResult {
- [key:string]:boolean;
+    [key: string]: boolean;
 }

--- a/BugTracker.App/Static/app/features/issues/view/editIssueCompontent.ts
+++ b/BugTracker.App/Static/app/features/issues/view/editIssueCompontent.ts
@@ -58,6 +58,7 @@ export class EditIussue {
         if (issueId != null) {
             this.issueModel = this.appStore.getState().issues.find(x => x.id == issueId);
             if (this.issueModel == null) {
+                this.editModel = new IssueModel().getUpdateModel();
                 console.error("Could not find issues with the id '" + issueId + "' in the AppStore.");
                 return;
             }

--- a/BugTracker.App/Static/app/features/issues/view/editIssueCompontent.ts
+++ b/BugTracker.App/Static/app/features/issues/view/editIssueCompontent.ts
@@ -48,7 +48,6 @@ export class EditIussue {
     private isNewItem: boolean;
 
     constructor(private appStore: AppStore, private formBuilder: FormBuilder, private issueService: IssueService, private router : Router, private routeParams: RouteParams) {
-
         this.setInputModel();
         this.setFormValidation();
     }

--- a/BugTracker.App/Static/app/features/issues/view/editIssueCompontent.ts
+++ b/BugTracker.App/Static/app/features/issues/view/editIssueCompontent.ts
@@ -1,19 +1,21 @@
-import { Component, Input, OnDestroy, OnInit, ChangeDetectionStrategy, ChangeDetectorRef } from "angular2/core";
-import {RouteParams} from 'angular2/router';
-import {NgForm, Control, ControlGroup, FormBuilder, Validators } from 'angular2/common';
+import { Component, Input, OnDestroy, OnInit} from "angular2/core";
+import { RouteParams } from 'angular2/router';
+import { NgForm, Control, ControlGroup, FormBuilder, Validators } from 'angular2/common';
 
 import { AppStore } from "../../../store/appStore";
 import { IssueModel, IIssueModelUpdate } from "../../../models/models";
+import { CustomValidators } from "../../../validations/customValidators"
+import { IssueService } from "../../../services/services"
+import { IssueStoreActions } from "../store/issueStoreActions";
 
 @Component(
     {
         selector: "edit-issue",
-        changeDetection: ChangeDetectionStrategy.OnPush,
         template: `
-            <form (ngSubmit)="onSubmit()" [ngFormModel]="issueForm">
+            <form (ngSubmit)="saveChanges()" #issueForm="ngForm" [ngFormModel]="issueFormModel">
                 <div class="form-group">
                     <label for="title">Title</label>
-                    <input required type="title" class="form-control" id="title" [(ngModel)]="editModel.title" ngControl="title"  #title="ngForm">
+                    <input type="title" class="form-control" id="title" [(ngModel)]="editModel.title" ngControl="title"  #title="ngForm">
                 </div>
                 
                 <div [hidden]="title.control.valid" class="alert alert-danger">
@@ -24,92 +26,79 @@ import { IssueModel, IIssueModelUpdate } from "../../../models/models";
                     <label for="content">Content</label>
                     <textarea class="form-control" rows="5" id="content" [(ngModel)]="editModel.content" ngControl="content" #content="ngForm"></textarea>
                 </div>
-                <div [hidden]="!content.control.hasError('startWithPlatos')" class="alert alert-danger">
-                    Content must start with 'Platos'
-                </div> 
-                
-                <div class="form-group">
-                    <label for="reportedDate">Closed</label>
-                    <input type="checkbox" value="">
-                </div>
-                <button type="submit" class="btn btn-default">Save</button>
+                <div [hidden]="!content.control.hasError('startWithUpperCase')" class="alert alert-danger">
+                    Content must start with upper case
+                </div>                 
+                <button type="submit" class="btn btn-default" [disabled]="!issueForm.form.valid">Save</button>
             </form>
         `
     })
 
 
 export class EditIussue implements OnInit, OnDestroy {
+
     private appStoreUnsubscribe: Function;
     private editModel: IIssueModelUpdate;
-    @Input() issue = new IssueModel({ title: "Test1", content: "Testcontent 1" });
-    @Input() simpleModel = new SimpleModel("Test1", "Test Content 1");
-    issueForm: ControlGroup;
+    private issueFormModel: ControlGroup;
+    private isNewItem: boolean;
 
-    constructor(private appStore: AppStore, private fb: FormBuilder, private changeDetectorRef: ChangeDetectorRef /*, private routeParams: RouteParams*/) {
+    constructor(private appStore: AppStore, private formBuilder: FormBuilder, private issueService: IssueService, private routeParams: RouteParams) {
 
-        this.issueForm = fb.group({
-            'title': ['', Validators.required],
-            'content': ['', CustomValidators.startWithPlatos]
-        }); 
-    
-        /*this.issue.
-        this.issue.setTitle("");
-        this.issue.setContent("");*/
-        
-        //this.issue.setTitle("test");
-        //console.log("tet");
-        // TODO: find issues based the id in the route parameter
-        //var issueId = routeParams.get('id'); 
-        
-        //this.issue = appStore.getState().issues.first();
+        var issueId = this.routeParams.get('id')
+        if (issueId != null) {
+            this.editModel = this.appStore.getState().issues.find(x => x.id == issueId).getUpdateModel();
+            this.editModel.userId = this.appStore.getState().currentUser.user.id;
+            this.isNewItem = false;
+        }
+        else {
+            this.isNewItem = true;
+        }
+
+        this.setFormValidation();
     }
 
-    onAppStoreUpdate() {
+    private setFormValidation() {
+        this.issueFormModel = this.formBuilder.group({
+            'title': ['', Validators.required],
+            'content': ['', CustomValidators.startWithUpperCase]
+        });
+    }
+
+    private saveChanges() {
+
+        var issueModel = new IssueModel(this.editModel);
+        
+        // call webApi
+        if (this.isNewItem) {
+            this.issueService.create(issueModel).then(
+                model => { this.appStore.dispatch(IssueStoreActions.AddIssue); },
+                error => { console.error("Could not create new issue", error); }
+            );
+        }
+        else {
+
+        }
+        // store dispatch
+        
+        // change route to issues list
+                
+        console.log("Changed object: ", new IssueModel(this.editModel));
+    }
+
+    public onAppStoreUpdate() {
         /*this.issue = this.appStore.getState().issues.first();
         if (this.issue != null) {
             console.log("TITEL: " + this.issue.title);
             this.changeDetectorRef.markForCheck();
         }*/
     }
-    ngOnInit() {
-        this.editModel = <IIssueModelUpdate> this.issue.toJS();
+    public ngOnInit() {
+        //this.editModel = <IIssueModelUpdate> this.issue.toJS();
         // this.appStoreUnsubscribe = this.appStore.subscribe(this.onAppStoreUpdate.bind(this));
         // this.onAppStoreUpdate();
     }
 
-    ngOnDestroy() {
+    public ngOnDestroy() {
         // this.appStoreUnsubscribe();
     }
-
-    public onSubmit() {
-        // call webApi
-        
-        // store dispatch
-        
-        // change route to issues list
-        
-        console.log("Changed object: ", new IssueModel(this.editModel));
-    }
-}
-
-export class SimpleModel {
-    title: string;
-    content: string;
-
-    constructor(title: string, content: string) {
-        this.title = title;
-        this.content = content;
-    }
-}
-
-
-
-export class CustomValidators {
-    static startWithPlatos(c: Control): ValidationResult {
-        return !c.value.match(/^Platos/) ? { "startWithPlatos": true } : null;
-    }
-}
-
-interface ValidationResult {
-    [key: string]: boolean;
 }

--- a/BugTracker.App/Static/app/features/issues/view/issuesContainerComponent.ts
+++ b/BugTracker.App/Static/app/features/issues/view/issuesContainerComponent.ts
@@ -1,6 +1,7 @@
 import { Component } from "angular2/core";
-import { AppStore } from "../../../store/appStore";
+import { Location } from "angular2/router";
 
+import { AppStore } from "../../../store/appStore";
 import { IssuesList } from "./issuesListComponent";
 import { AddNewIssue } from "./addNewIssueComponent";
 
@@ -8,13 +9,22 @@ import { AddNewIssue } from "./addNewIssueComponent";
     selector: "issues-container",
     directives: [IssuesList, AddNewIssue],
     template: `
-        <add-new-issue></add-new-issue>
+        <Button (click)="newIssue()">New Issue</Button>
+        
+        <br />
+        <br />       
+        
         <issue-list></issue-list>
     `
 })
 
 export class IssuesContainer {
-    constructor(private appStore: AppStore) {
+    constructor(private appStore: AppStore, private location : Location) {
 
+    }
+    
+    private newIssue()
+    {
+        this.location.go('/editLocation');
     }
 }

--- a/BugTracker.App/Static/app/features/issues/view/issuesListComponent.ts
+++ b/BugTracker.App/Static/app/features/issues/view/issuesListComponent.ts
@@ -1,6 +1,8 @@
 import { List } from 'immutable';
 
 import { Component, OnDestroy, OnInit, ChangeDetectionStrategy, ChangeDetectorRef } from "angular2/core";
+import { Router } from "angular2/router";
+
 import { AppStore } from "../../../store/appStore";
 import { IssueModel } from "../../../models/models";
 
@@ -21,7 +23,7 @@ import { IssueService } from "../../../services/services"
                 <th>Closed</th>
             </tr>
             <tr *ngFor="#issue of issues">
-                <td><button class="glyphicon glyphicon-edit"></button></td>
+                <td><button class="glyphicon glyphicon-edit" (click)="editIssue(issue.id)"></button></td>
                 <td><button class="glyphicon glyphicon-trash"></button></td>
                 <td>{{ issue.title }}</td>
                 <td>{{ issue.content }}</td>
@@ -35,17 +37,25 @@ import { IssueService } from "../../../services/services"
 export class IssuesList implements OnInit, OnDestroy {
     private appStoreUnsubscribe: Function;
     private issues: List<IssueModel>;
-    constructor(private appStore: AppStore, private changeDetectorRef: ChangeDetectorRef, private issueService: IssueService) {
+    
+    constructor(private appStore: AppStore, private changeDetectorRef: ChangeDetectorRef, private issueService: IssueService, private router : Router) {
     }
+    
     onAppStoreUpdate() {
         this.issues = this.appStore.getState().issues;
-        this.changeDetectorRef.markForCheck();
+        this.changeDetectorRef.markForCheck();        
     }
+    
     ngOnInit() {
         this.appStoreUnsubscribe = this.appStore.subscribe(this.onAppStoreUpdate.bind(this));
         this.onAppStoreUpdate();
 
         this.loadIssues();
+    }
+    
+    private editIssue (issueId : string)
+    {
+        this.router.navigate(['EditIssues', {id: issueId}]);       
     }
 
     private loadIssues() {
@@ -61,6 +71,7 @@ export class IssuesList implements OnInit, OnDestroy {
     ngOnDestroy() {
         this.appStoreUnsubscribe();
     }
+    
     issueChanged(issueModel: IssueModel) {
         this.appStore.dispatch(IssueStoreActions.ChangeTitle(issueModel.title));
     }

--- a/BugTracker.App/Static/app/models/generated/GernateModels.tst
+++ b/BugTracker.App/Static/app/models/generated/GernateModels.tst
@@ -109,6 +109,7 @@
     string singularCamelCase(Property p) { return p.Type.IsEnumerable ? p.name.Substring(0, p.name.Length -1) : p.name; }
     string singularPascalCase(Property p) { return p.Type.IsEnumerable ? p.Name.Substring(0, p.Name.Length -1) : p.Name; }
     string getIModelUpdateName(Class c) { return getIModelName(c) + "Update"; }
+    string getIModelUpdateMethodeName(Class c) { return "get" + getIModelName(c) + "UpdateObject"; }
     string getIModelName(Class c) { return "I" + c.Name; }
 }import * as Immutable from 'immutable';
 import * as ModelMeta from '../../utils/model/meta';
@@ -144,6 +145,9 @@ export class $Name implements $getIModelName, ModelMeta.IClassHasMetaImplements 
     public updateFromModel(updateObject: $getIModelUpdateName): $Name {
         var newRecord = this._record.withMutations(map => ModelBase.updateFromModel(map, updateObject));
         return new $Name(newRecord);
+    }
+    public $getIModelUpdateMethodeName(): $getIModelUpdateName {
+        return <$getIModelUpdateName> this._record.toJS();
     }
     $Properties(p => p.HasSetter)[public set$Name($name: $getModelTypeRepresentation): $getParentClassName {
         return new $getParentClassName(this._record.set('$name', $name));

--- a/BugTracker.App/Static/app/models/generated/GernateModels.tst
+++ b/BugTracker.App/Static/app/models/generated/GernateModels.tst
@@ -146,7 +146,7 @@ export class $Name implements $getIModelName, ModelMeta.IClassHasMetaImplements 
         var newRecord = this._record.withMutations(map => ModelBase.updateFromModel(map, updateObject));
         return new $Name(newRecord);
     }
-    public $getIModelUpdateMethodeName(): $getIModelUpdateName {
+    public getUpdateModel(): $getIModelUpdateName {
         return <$getIModelUpdateName> this._record.toJS();
     }
     $Properties(p => p.HasSetter)[public set$Name($name: $getModelTypeRepresentation): $getParentClassName {

--- a/BugTracker.App/Static/app/models/generated/currentUserState.ts
+++ b/BugTracker.App/Static/app/models/generated/currentUserState.ts
@@ -26,7 +26,7 @@ export class CurrentUserState implements ICurrentUserState, ModelMeta.IClassHasM
         var newRecord = this._record.withMutations(map => ModelBase.updateFromModel(map, updateObject));
         return new CurrentUserState(newRecord);
     }
-    public getICurrentUserStateUpdateObject(): ICurrentUserStateUpdate {
+    public getUpdateModel(): ICurrentUserStateUpdate {
         return <ICurrentUserStateUpdate> this._record.toJS();
     }
     public setUser(user: Models.UserModel): CurrentUserState {

--- a/BugTracker.App/Static/app/models/generated/currentUserState.ts
+++ b/BugTracker.App/Static/app/models/generated/currentUserState.ts
@@ -26,6 +26,9 @@ export class CurrentUserState implements ICurrentUserState, ModelMeta.IClassHasM
         var newRecord = this._record.withMutations(map => ModelBase.updateFromModel(map, updateObject));
         return new CurrentUserState(newRecord);
     }
+    public getICurrentUserStateUpdateObject(): ICurrentUserStateUpdate {
+        return <ICurrentUserStateUpdate> this._record.toJS();
+    }
     public setUser(user: Models.UserModel): CurrentUserState {
         return new CurrentUserState(this._record.set('user', user));
     }

--- a/BugTracker.App/Static/app/models/generated/issueModel.ts
+++ b/BugTracker.App/Static/app/models/generated/issueModel.ts
@@ -61,7 +61,7 @@ export class IssueModel implements IIssueModel, ModelMeta.IClassHasMetaImplement
         var newRecord = this._record.withMutations(map => ModelBase.updateFromModel(map, updateObject));
         return new IssueModel(newRecord);
     }
-    public getIIssueModelUpdateObject(): IIssueModelUpdate {
+    public getUpdateModel(): IIssueModelUpdate {
         return <IIssueModelUpdate> this._record.toJS();
     }
     public setId(id: string): IssueModel {

--- a/BugTracker.App/Static/app/models/generated/issueModel.ts
+++ b/BugTracker.App/Static/app/models/generated/issueModel.ts
@@ -61,6 +61,9 @@ export class IssueModel implements IIssueModel, ModelMeta.IClassHasMetaImplement
         var newRecord = this._record.withMutations(map => ModelBase.updateFromModel(map, updateObject));
         return new IssueModel(newRecord);
     }
+    public getIIssueModelUpdateObject(): IIssueModelUpdate {
+        return <IIssueModelUpdate> this._record.toJS();
+    }
     public setId(id: string): IssueModel {
         return new IssueModel(this._record.set('id', id));
     }

--- a/BugTracker.App/Static/app/models/generated/registerUserModel.ts
+++ b/BugTracker.App/Static/app/models/generated/registerUserModel.ts
@@ -26,6 +26,9 @@ export class RegisterUserModel implements IRegisterUserModel, ModelMeta.IClassHa
         var newRecord = this._record.withMutations(map => ModelBase.updateFromModel(map, updateObject));
         return new RegisterUserModel(newRecord);
     }
+    public getIRegisterUserModelUpdateObject(): IRegisterUserModelUpdate {
+        return <IRegisterUserModelUpdate> this._record.toJS();
+    }
     public setUsername(username: string): RegisterUserModel {
         return new RegisterUserModel(this._record.set('username', username));
     }

--- a/BugTracker.App/Static/app/models/generated/registerUserModel.ts
+++ b/BugTracker.App/Static/app/models/generated/registerUserModel.ts
@@ -26,7 +26,7 @@ export class RegisterUserModel implements IRegisterUserModel, ModelMeta.IClassHa
         var newRecord = this._record.withMutations(map => ModelBase.updateFromModel(map, updateObject));
         return new RegisterUserModel(newRecord);
     }
-    public getIRegisterUserModelUpdateObject(): IRegisterUserModelUpdate {
+    public getUpdateModel(): IRegisterUserModelUpdate {
         return <IRegisterUserModelUpdate> this._record.toJS();
     }
     public setUsername(username: string): RegisterUserModel {

--- a/BugTracker.App/Static/app/models/generated/userModel.ts
+++ b/BugTracker.App/Static/app/models/generated/userModel.ts
@@ -33,6 +33,9 @@ export class UserModel implements IUserModel, ModelMeta.IClassHasMetaImplements 
         var newRecord = this._record.withMutations(map => ModelBase.updateFromModel(map, updateObject));
         return new UserModel(newRecord);
     }
+    public getIUserModelUpdateObject(): IUserModelUpdate {
+        return <IUserModelUpdate> this._record.toJS();
+    }
     public setId(id: string): UserModel {
         return new UserModel(this._record.set('id', id));
     }

--- a/BugTracker.App/Static/app/models/generated/userModel.ts
+++ b/BugTracker.App/Static/app/models/generated/userModel.ts
@@ -33,7 +33,7 @@ export class UserModel implements IUserModel, ModelMeta.IClassHasMetaImplements 
         var newRecord = this._record.withMutations(map => ModelBase.updateFromModel(map, updateObject));
         return new UserModel(newRecord);
     }
-    public getIUserModelUpdateObject(): IUserModelUpdate {
+    public getUpdateModel(): IUserModelUpdate {
         return <IUserModelUpdate> this._record.toJS();
     }
     public setId(id: string): UserModel {

--- a/BugTracker.App/Static/app/models/models.ts
+++ b/BugTracker.App/Static/app/models/models.ts
@@ -1,6 +1,6 @@
 export { IReducerAppState, AppState } from './generated/appState';
 
-export { CurrentUserState } from './generated/currentUserState';
-export { IssueModel } from './generated/issueModel';
-export { RegisterUserModel } from './generated/registerUserModel';
-export { UserModel } from './generated/userModel';
+export { CurrentUserState, ICurrentUserStateUpdate } from './generated/currentUserState';
+export { IssueModel, IIssueModelUpdate } from './generated/issueModel';
+export { RegisterUserModel, IRegisterUserModelUpdate } from './generated/registerUserModel';
+export { UserModel, IUserModelUpdate } from './generated/userModel';

--- a/BugTracker.App/Static/app/services/authService.ts
+++ b/BugTracker.App/Static/app/services/authService.ts
@@ -1,0 +1,31 @@
+import {Injectable, provide} from 'angular2/core';
+
+import { UserModel, IUserModelUpdate } from '../models/models';
+
+@Injectable()
+export class AuthService {
+    private static USER_STORAGE_KEY: string = "user";
+
+    public getUserFromLocalStorage(): UserModel {
+        var plainUserObject = localStorage.getItem(AuthService.USER_STORAGE_KEY);
+        if (plainUserObject == null) {
+            return null;
+        }
+
+        var storedUser = <IUserModelUpdate>JSON.parse(plainUserObject);
+        return new UserModel(storedUser);
+    }
+
+    public setUserToLocalStorage(user: UserModel) {
+        var plainUserObject = JSON.stringify(user.getUpdateModel());
+        localStorage.setItem(AuthService.USER_STORAGE_KEY, plainUserObject);
+    }
+
+    public removeUserFromLocalStorage() {
+        localStorage.removeItem(AuthService.USER_STORAGE_KEY);
+    }
+}
+
+export var AUTH_PROVIDERS: Array<any> = [
+    provide(AuthService, { useClass: AuthService })
+];

--- a/BugTracker.App/Static/app/services/generated/issueService.ts
+++ b/BugTracker.App/Static/app/services/generated/issueService.ts
@@ -24,6 +24,18 @@ export class IssueService {
             })
             .toPromise();
     }
+    public update(issueModel: Models.IssueModel): ServiceBase.IPromise {
+        
+        return this.http
+            .request(`api/issue/Update`, {
+                method: "put",
+                body: ServiceBase.stringifyBody(issueModel)
+            })
+            .map(response => {
+                return null;
+            })
+            .toPromise();
+    }
     public getAllByUser(userId: string): ServiceBase.ITypedPromise<Immutable.List<Models.IssueModel>> {
         
         return this.http

--- a/BugTracker.App/Static/app/services/service.base.ts
+++ b/BugTracker.App/Static/app/services/service.base.ts
@@ -1,7 +1,6 @@
 import { Iterable } from 'immutable';
 import { Injectable } from "angular2/core";
-import { Headers, BaseRequestOptions, RequestOptionsArgs, RequestOptions } from 'angular2/http';
-import { AppConfiguration } from '../config/config.base';
+
 import { IModelWithRecord } from '../utils/model/meta';
 
 export interface ITypedPromise<T> {
@@ -28,20 +27,3 @@ export function stringifyBody(value: Iterable<any, any> | IModelWithRecord | any
     return stringified;
 }
 
-@Injectable()
-export class DefaultRequestOptions extends BaseRequestOptions {
-    
-    constructor (private config : AppConfiguration)
-    {   
-        super();   
-    }
-    
-    headers = new Headers({
-        'Content-Type': 'application/json'
-    });
-
-    merge(options?: RequestOptionsArgs): RequestOptions {
-        options.url = this.config.baseApiUrl + options.url;
-        return super.merge(options);
-    }
-}

--- a/BugTracker.App/Static/app/services/services.ts
+++ b/BugTracker.App/Static/app/services/services.ts
@@ -2,6 +2,7 @@ import { provide } from "angular2/core";
 import { IssueService } from './generated/issueService';
 import { UserService } from './generated/userService';
 import { TypewriterTestService } from './generated/typewriterTestService';
+import { AuthService } from './authService';
 
 export { IssueService, UserService, TypewriterTestService };
 
@@ -9,4 +10,8 @@ export const APP_WEBSERVICES: any[] = [
     provide(IssueService, { useClass: IssueService }),
     provide(UserService, { useClass: UserService }),
     provide(TypewriterTestService, { useClass: TypewriterTestService })
+];
+
+export var AUTH_SERVICES: Array<any> = [
+  provide(AuthService, {useClass: AuthService})
 ];

--- a/BugTracker.App/Static/app/utils/defaultRequestOptions.ts
+++ b/BugTracker.App/Static/app/utils/defaultRequestOptions.ts
@@ -1,0 +1,21 @@
+import { AppConfiguration } from '../config/config.base';
+import { Headers, BaseRequestOptions, RequestOptionsArgs, RequestOptions } from 'angular2/http';
+import { Injectable } from "angular2/core";
+
+@Injectable()
+export class DefaultRequestOptions extends BaseRequestOptions {
+    
+    constructor (private config : AppConfiguration)
+    {   
+        super();   
+    }
+    
+    headers = new Headers({
+        'Content-Type': 'application/json'
+    });
+
+    merge(options?: RequestOptionsArgs): RequestOptions {
+        options.url = this.config.baseApiUrl + options.url;
+        return super.merge(options);
+    }
+}

--- a/BugTracker.App/Static/app/validations/customValidators.ts
+++ b/BugTracker.App/Static/app/validations/customValidators.ts
@@ -2,9 +2,9 @@ import { Control } from 'angular2/common';
 
 export class CustomValidators {
     
-    static startsWithNumber(control: Control): ValidationResult {
+    static startsWithoutNumber(control: Control): ValidationResult {
         if (control.value !="" && !isNaN(control.value.charAt(0)) ){
-            return { "startsWithNumber": true };
+            return { "startsWithoutNumber": true };
         }
         return null;
     }

--- a/BugTracker.App/Static/app/validations/customValidators.ts
+++ b/BugTracker.App/Static/app/validations/customValidators.ts
@@ -1,15 +1,35 @@
 import { Control } from 'angular2/common';
+import { IValidationResult, getValidationResult  } from './validationResult';
 
 export class CustomValidators {
     
-    static startsWithoutNumber(control: Control): ValidationResult {
-        if (control.value !="" && !isNaN(control.value.charAt(0)) ){
-            return { "startsWithoutNumber": true };
+    static startsWithoutNumber(control: Control): IValidationResult {
+        
+        var validationResult = getValidationResult("startsWithoutNumber");
+        
+        if (control.value == null)
+        {
+            return validationResult;
+        }
+        if (!control.value.match(/^\d+/))
+        {
+            return validationResult;
         }
         return null;
     }
     
-    static startWithUpperCase(c: Control): ValidationResult {
-        return !c.value.match(/^[A-Z]+[a-z][A-Z]*/) ? { "startWithUpperCase": true } : null;
+    static startWithUpperCase(control: Control): IValidationResult {
+        
+        var validationResult = getValidationResult("startWithUpperCase");
+        
+        if (control.value == null)
+        {
+            return validationResult;
+        }
+        if (!control.value.match(/^[A-Z]+[a-z][A-Z]*/))
+        {
+            return validationResult;
+        }
+        return null;
     }
 }

--- a/BugTracker.App/Static/app/validations/customValidators.ts
+++ b/BugTracker.App/Static/app/validations/customValidators.ts
@@ -1,0 +1,15 @@
+import { Control } from 'angular2/common';
+
+export class CustomValidators {
+    
+    static startsWithNumber(control: Control): ValidationResult {
+        if (control.value !="" && !isNaN(control.value.charAt(0)) ){
+            return { "startsWithNumber": true };
+        }
+        return null;
+    }
+    
+    static startWithUpperCase(c: Control): ValidationResult {
+        return !c.value.match(/^[A-Z]+[a-z][A-Z]*/) ? { "startWithUpperCase": true } : null;
+    }
+}

--- a/BugTracker.App/Static/app/validations/validationResult.ts
+++ b/BugTracker.App/Static/app/validations/validationResult.ts
@@ -1,3 +1,8 @@
-interface ValidationResult {
+export interface IValidationResult {
     [key: string]: boolean;
+}
+
+export function getValidationResult(validationKey: string): IValidationResult {    
+    var jsonString = "{\"" + validationKey + "\": \"true\" }";   
+    return <IValidationResult> JSON.parse(jsonString);
 }

--- a/BugTracker.App/Static/app/validations/validationResult.ts
+++ b/BugTracker.App/Static/app/validations/validationResult.ts
@@ -1,0 +1,3 @@
+interface ValidationResult {
+    [key: string]: boolean;
+}

--- a/BugTracker.App/package.json
+++ b/BugTracker.App/package.json
@@ -14,7 +14,7 @@
     "tsc": "tsc | findstr /C:\"Static/\"",
     "tscw": "tsc -w",
     "typings": "typings install",
-    "liveserver": "live-server --open=static --ignorePattern=\".*\\.(ts|map)\"",
+    "liveserver": "live-server --open=static --entry-file=\"static/index.html\" --ignorePattern=\".*\\.(ts|map)\"",
     "start-dev": "npm run npm-install && npm run typings && concurrent \"npm run tscw\" \"npm run liveserver\""
   },
   "engines": {

--- a/BugTracker.Data/Repositories/Abstract/IIssueAccess.cs
+++ b/BugTracker.Data/Repositories/Abstract/IIssueAccess.cs
@@ -8,6 +8,7 @@ namespace BugTracker.Data.Repositories.Abstract
     public interface IIssueAccess
     {
         Issue Add(Guid userId, string title, string content);
+        void Update(Guid issueId, string title, string content, bool isClosed);
         List<Issue> GetAllByUserId(Guid userId);
     }
 }

--- a/BugTracker.Data/Repositories/IssueAccess.cs
+++ b/BugTracker.Data/Repositories/IssueAccess.cs
@@ -37,6 +37,26 @@ namespace BugTracker.Data.Repositories
             return issue;
         }
 
+        public void Update(Guid issueId, string title, string content, bool isClosed)
+        {
+            Check.IsNotNull(nameof(title), title);
+            Check.IsNotNull(nameof(content), content);
+
+            var existingEntity = this.database.Get<Issue>(issueId);
+
+            if (existingEntity == null)
+            {
+                throw new Exception($"Could not found issue with the Id {issueId}.");
+            }
+
+            existingEntity.Content = content;
+            existingEntity.Title = title;
+            existingEntity.IsClosed = isClosed;
+
+            this.database.Remove<Issue>(issueId);
+            this.database.Add<Issue>(issueId, existingEntity);
+        }
+
         public List<Issue> GetAllByUserId(Guid userId)
         {
             var issues = this.database.GetAll<Issue>()


### PR DESCRIPTION
- edit issues: store changes on server site (MemoryDatabase) and update AppStore
- form validation
- basic routing
- store "CurrentUser" to the local storage: So you are logged in after a page refresh

**What is still missing**
- direct URL request e.q http://127.0.0.1:8080/static/editIssue/4e823e4a-2f0c-4248-80b3-8173cb87e71a  At the moment this fails, because the issue is not in the AppStore, because the issues are loaded and added to the AppStore in the "IssuesListComponent"

- A correct way of loading the issue list: At the moment the issues will be load in the` ngOnInit() { ... }` method. The problem is, that the ngOnInit will be call when the app routes to the issue-list component. This means the issue list will be multiply with every call. The problem could be reproduced, if you click to the "Edit" button in the list and then go back.